### PR TITLE
fix: export footer components

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,3 +9,5 @@ export * from "./components/list/list";
 export * from "./components/list-item/list-item";
 export * from "./components/instruments/instruments";
 export * from "./components/instruments-item/instruments-item";
+export * from "./components/footer/footer-links";
+export * from "./components/footer/footer";


### PR DESCRIPTION
### What changed?

Exports footer components when we build the package.
