### PR TITLE
Enabling wrapping for items with logos

### DIFF
--- a/src/components/developed-by/developed-by.js
+++ b/src/components/developed-by/developed-by.js
@@ -10,39 +10,35 @@ export const DevelopedBy = ({ showSecondLine }) => {
   return (
     <>
       <div className="container developed-by">
-        <span>
-          <div>
-            <div className="caption">Un proiect în parteneriat cu </div>
-            <Logo
-              src={partnerLogo}
-              url={"https://www.gov.ro"}
-              alt={"Guvernul Romaniei Logo"}
-            />
-          </div>
+        <div>
+          <div className="caption">Un proiect în parteneriat cu </div>
+          <Logo
+            src={partnerLogo}
+            url={"https://www.gov.ro"}
+            alt={"Guvernul Romaniei Logo"}
+          />
+        </div>
 
-          <div>
-            <div className="caption"> dezvoltat de </div>
-            <Logo
-              src={developerLogo}
-              url={"https://code4.ro"}
-              alt={"Code 4 Romania Logo"}
-              imgClass={"smaller"}
-            />
-          </div>
-        </span>
+        <div>
+          <div className="caption"> dezvoltat de </div>
+          <Logo
+            src={developerLogo}
+            url={"https://code4.ro"}
+            alt={"Code 4 Romania Logo"}
+            imgClass={"smaller"}
+          />
+        </div>
       </div>
       {showSecondLine && (
         <div className="container developed-by">
-          <span>
-            <div>
-              <div className="caption">Conținut avizat de</div>
-              <Logo
-                src={dsuLogo}
-                url={"http://www.dsu.mai.gov.ro/"}
-                alt={"Directia pentru Situatii de Urgenta Logo"}
-              />
-            </div>
-          </span>
+          <div>
+            <div className="caption">Conținut avizat de</div>
+            <Logo
+              src={dsuLogo}
+              url={"http://www.dsu.mai.gov.ro/"}
+              alt={"Directia pentru Situatii de Urgenta Logo"}
+            />
+          </div>
         </div>
       )}
     </>

--- a/src/components/developed-by/developed-by.scss
+++ b/src/components/developed-by/developed-by.scss
@@ -4,18 +4,15 @@
   display: flex;
   flex-direction: row;
   justify-content: flex-end;
-  align-items: center;
+  align-items: stretch;
+  flex-wrap: wrap;
 
-  > span {
+  > div {
     display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-around;
     border-bottom: 1px solid #e5e5e5;
     padding: 0.75em 0;
-
-> div {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: space-around;
-}
-}
+  }
 }


### PR DESCRIPTION
Removed the span to have an simpler structured

Please mention the main changes this PR brings.

- Items with logos now wrap on the next line instead of being squeezed - see before and after screenshots

Before:
<img width="427" alt="Screen Shot 2020-03-21 at 17 10 41" src="https://user-images.githubusercontent.com/1107449/77232142-3ca68080-6b97-11ea-8d95-980f45a53765.png">

After:
<img width="400" alt="Screen Shot 2020-03-21 at 17 10 56" src="https://user-images.githubusercontent.com/1107449/77232159-45975200-6b97-11ea-9076-c6cf967d743d.png">


