### PR TITLE
Make the email input required.

### DIFF
--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -16,6 +16,7 @@ export const Input = ({
   defaultValue,
   children,
   hasAddons,
+  required,
   onChange
 }) => {
   const inputClassNames = ["input"];
@@ -40,6 +41,7 @@ export const Input = ({
           defaultValue={defaultValue}
           placeholder={usePlaceholder ? label : ""}
           onChange={onChange}
+          required={required}
         />
       </div>
       {children}
@@ -57,6 +59,7 @@ Input.propTypes = {
   hasAddons: PropTypes.bool,
   loading: PropTypes.bool,
   rounded: PropTypes.bool,
+  required: PropTypes.bool,
   defaultValue: PropTypes.string,
   usePlaceholder: PropTypes.bool,
   children: PropTypes.node,
@@ -69,5 +72,6 @@ Input.defaultProps = {
   disabled: false,
   loading: false,
   rounded: false,
-  usePlaceholder: false
+  usePlaceholder: false,
+  required: false
 };

--- a/src/components/subscribe/constants.js
+++ b/src/components/subscribe/constants.js
@@ -1,8 +1,8 @@
 export const Wording = {
   TITLE: "Rămâi informat",
   SUB_TITLE:
-    "Abonează-te la newsletter și te ținem la curent cu cele mai importante \
-    informații și cu toate soluțiile digitale pe care le dezvoltăm în cadrul acestui proiect.",
+    `Abonează-te la newsletter și te ținem la curent cu cele mai importante
+    informații și cu toate soluțiile digitale pe care le dezvoltăm în cadrul acestui proiect.`,
   PLACEHOLDER: "Introdu aici adresa de e-mail",
   BUTTON: "Abonează-mă",
   SUCCESS: "Abonare reușită!",

--- a/src/components/subscribe/constants.js
+++ b/src/components/subscribe/constants.js
@@ -1,7 +1,8 @@
 export const Wording = {
   TITLE: "Rămâi informat",
   SUB_TITLE:
-    "Abonează-te la newsletter și îți trimitem zilnic ultimele informații!",
+    "Abonează-te la newsletter și te ținem la curent cu cele mai importante \
+    informații și cu toate soluțiile digitale pe care le dezvoltăm în cadrul acestui proiect.",
   PLACEHOLDER: "Introdu aici adresa de e-mail",
   BUTTON: "Abonează-mă",
   SUCCESS: "Abonare reușită!",

--- a/src/components/subscribe/subscribe-form.js
+++ b/src/components/subscribe/subscribe-form.js
@@ -31,6 +31,7 @@ export const SubscribeForm = ({ compact }) => {
         label={Wording.PLACEHOLDER}
         name={Wording.MAILCHIMP_INPUT_NAME}
         usePlaceholder={true}
+        required={true}
       >
         {!compact && (
           <div className="control">


### PR DESCRIPTION
### What changed?
* Added required flag to the input component
* Made the email input field required
* Fixed the subtitle to match the text on stirioficiale.ro

### Actions (optional)
 - [ ] Maybe make the subscribe component configurable in terms of wording. Like having the current hard coded defaults. But leave the user the option to provide his own wording(title, subtitle, placeholder, button text)

@aniri @moonflare ^^

