### PR TITLE
fix back-to-top export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@code4ro/taskforce-fe-components",
-  "version": "1.0.4",
+  "version": "1.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@code4ro/taskforce-fe-components",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code4ro/taskforce-fe-components",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "private": false,
   "dependencies": {
     "bulma": "^0.8.0",

--- a/src/components/back-to-top/back-to-top.js
+++ b/src/components/back-to-top/back-to-top.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import ArrowUp from "../../images/icons/circle-up.svg";
 import "./back-to-top.scss";
 
-const BackToTop = ({ width, height }) => {
+export const BackToTop = ({ width, height }) => {
   return (
     <div
       className="back-to-top"
@@ -19,7 +19,6 @@ const BackToTop = ({ width, height }) => {
     </div>
   );
 };
-export default BackToTop;
 
 BackToTop.propTypes = {
   width: PropTypes.number,

--- a/src/components/back-to-top/back-to-top.stories.js
+++ b/src/components/back-to-top/back-to-top.stories.js
@@ -1,5 +1,5 @@
 import React from "react";
-import BackToTop from "./back-to-top";
+import { BackToTop } from "./back-to-top";
 
 export default { title: "Back To Top" };
 export const Default = () => <BackToTop />;


### PR DESCRIPTION
### What changed?
 - Fixes the export/import of back-to-top
 - The component couldn't be used because if was exported as default

### Actions (optional)
 - [x] Increase the version of the package if you need to release it after the merge
 - [x] If you added a new component, please make sure to export it in `../src/index.js`

