### PR TITLE
Fix form on finish

### DIFF
--- a/src/components/form/form.js
+++ b/src/components/form/form.js
@@ -87,7 +87,6 @@ export const Form = ({ data, evaluateForm, onFinishingForm }) => {
         );
       }
       case "FINAL": {
-        onFinishingForm(createFormWithAnswers());
         return (
           <StaticText
             title={currentQuestion.questionText}
@@ -121,6 +120,11 @@ export const Form = ({ data, evaluateForm, onFinishingForm }) => {
 
       historyOfSteps.push(currentNode);
       setHistoryOfSteps(historyOfSteps);
+
+      if (formAsMap[nextNode].type === "FINAL") {
+        onFinishingForm(createFormWithAnswers());
+      }
+
       setCurrentNode(nextNode);
     }
   };

--- a/src/components/form/form.test.js
+++ b/src/components/form/form.test.js
@@ -1,11 +1,10 @@
-import React from "react";
+import React, { useState } from "react";
 import { mount } from "enzyme";
 import { ListHeader } from "../list-header/list-header";
 import { ListItem } from "../list-item/list-item";
 import { Form } from "./form";
 import SingleChoice from "./singleChoice";
 import FreeText from "./freeText";
-import MultipleChoice from "./multipleChoice";
 
 const clickOnNext = form => {
   const forwardButton = form.find(".forward");
@@ -22,11 +21,6 @@ const clickOnSingleChoice = (form, choice) => {
   answer.simulate("click");
 };
 
-const clickOnMultipleChoice = (form, choice) => {
-  const answer = form.find(MultipleChoice).find({ title: choice });
-  answer.simulate("click");
-};
-
 function startForm(form) {
   form.find(".start").simulate("click");
 }
@@ -40,63 +34,44 @@ const expectHeaderText = (form, expected) => {
   expect(form.find(ListHeader).text()).toEqual(expected);
 };
 
+const oneQuestionForm = {
+  title: "One question form",
+  formId: 1,
+  firstNodeId: 1,
+  form: [
+    {
+      questionId: 1,
+      questionText: "Ai peste 60 de ani?",
+      type: "SINGLE_CHOICE",
+      options: [
+        {
+          label: "Da",
+          value: 1
+        },
+        {
+          label: "Nu",
+          value: 0
+        }
+      ]
+    },
+    {
+      questionId: 2,
+      questionText: "Done!",
+      type: "FINAL",
+      options: [
+        outcome,
+        {
+          label: "Stay at home",
+          value: 1
+        }
+      ]
+    }
+  ]
+};
+
 describe("Form", () => {
   it("See the final text after a simple form", () => {
     const mockFinishingForm = jest.fn();
-
-    const oneQuestionForm = {
-      title: "One question form",
-      formId: 1,
-      firstNodeId: 1,
-      form: [
-        {
-          questionId: 1,
-          questionText: "Ai peste 60 de ani?",
-          type: "SINGLE_CHOICE",
-          options: [
-            {
-              label: "Da",
-              value: 1
-            },
-            {
-              label: "Nu",
-              value: 0
-            }
-          ]
-        },
-        {
-          questionId: 2,
-          questionText: "Ce simptome ai?",
-          type: "MULTIPLE_CHOICE",
-          options: [
-            {
-              label: "Tuse",
-              value: 0
-            },
-            {
-              label: "Febra",
-              value: 1
-            },
-            {
-              label: "Dureri de cap",
-              value: 2
-            }
-          ]
-        },
-        {
-          questionId: 3,
-          questionText: "Done!",
-          type: "FINAL",
-          options: [
-            outcome,
-            {
-              label: "Stay at home",
-              value: 1
-            }
-          ]
-        }
-      ]
-    };
 
     const form = mount(
       <Form
@@ -111,10 +86,6 @@ describe("Form", () => {
     clickOnSingleChoice(form, "Da");
     clickOnNext(form);
 
-    clickOnMultipleChoice(form, "Febra");
-    clickOnMultipleChoice(form, "Tuse");
-    clickOnNext(form);
-
     expectHeaderText(form, "Done!");
 
     const actualAnswers = mockFinishingForm.mock.calls[0][0].answers;
@@ -123,11 +94,6 @@ describe("Form", () => {
         id: 1,
         questionText: "Ai peste 60 de ani?",
         answer: "1"
-      },
-      {
-        id: 2,
-        questionText: "Ce simptome ai?",
-        answer: "1,0"
       }
     ]);
   });
@@ -233,4 +199,40 @@ describe("Form", () => {
 
     expectHeaderText(form, "Done!");
   });
+
+  describe("rendered in a container", () => {
+    it("only calls onFinishForm when there is more state in the container", () => {
+      const onFinishMock = jest.fn();
+      const testContainer = mount(
+        <TestContainer finishSideEffect={onFinishMock} />
+      );
+
+      const form = testContainer.find(Form);
+
+      clickOnSingleChoice(form, "Da");
+      clickOnNext(form);
+
+      expect(onFinishMock).toHaveBeenCalledTimes(1);
+    });
+  });
 });
+
+// eslint-disable-next-line react/prop-types
+const TestContainer = ({ finishSideEffect }) => {
+  const [finished, setFinished] = useState(false);
+  return (
+    <div>
+      {finished}
+      <Form
+        data={oneQuestionForm}
+        evaluateForm={() => {
+          return { label: "finished" };
+        }}
+        onFinishingForm={() => {
+          setFinished(true);
+          finishSideEffect();
+        }}
+      />
+    </div>
+  );
+};

--- a/src/components/form/multipleChoice.js
+++ b/src/components/form/multipleChoice.js
@@ -46,9 +46,11 @@ function MultipleChoice({ question, onAnswer, currentResponse = [] }) {
         existingValue = currentResponse[size - 1];
       }
       return (
-        <div className={"__list-item other"}>
+        <div
+          className={"__list-item other"}
+          key={`answer_${question.questionId}_${option.value}`}
+        >
           <Input
-            key={`answer_${question.questionId}_${option.value}`}
             usePlaceholder={false}
             onChange={onInputForOther}
             defaultValue={existingValue}


### PR DESCRIPTION
### What changed?
- Moved the call to onFinishForm to the click on the last next button from on rendering the final part of the form. This fixes an issue where in some cases (eg in the testcase) the onFinishForm callback is called more than once. 

- Fixed browser warning related to wrongly positioned key prop