### PR TITLE
Multiple free text choices on a multiple choice question

### DIFF
--- a/src/components/form/data/decisionTree.js
+++ b/src/components/form/data/decisionTree.js
@@ -90,6 +90,7 @@ export default {
           value: 0
         },
         {
+          type: "OTHER",
           label: "Febra",
           value: 1
         },

--- a/src/components/form/form.js
+++ b/src/components/form/form.js
@@ -46,7 +46,7 @@ export const Form = ({ data, evaluateForm, onFinishingForm }) => {
       return {
         id: question.questionId,
         questionText: question.questionText,
-        answer: String(formState[id])
+        answer: formState[id]
       };
     });
     return {

--- a/src/components/form/form.js
+++ b/src/components/form/form.js
@@ -43,10 +43,16 @@ export const Form = ({ data, evaluateForm, onFinishingForm }) => {
         return {};
       }
 
+      let answer = formState[id];
+
+      if (question.type === "SINGLE_CHOICE") {
+        answer = String(answer);
+      }
+
       return {
         id: question.questionId,
         questionText: question.questionText,
-        answer: formState[id]
+        answer: answer
       };
     });
     return {

--- a/src/components/form/form.test.js
+++ b/src/components/form/form.test.js
@@ -5,6 +5,7 @@ import { ListItem } from "../list-item/list-item";
 import { Form } from "./form";
 import SingleChoice from "./singleChoice";
 import FreeText from "./freeText";
+import MultipleChoice from "./multipleChoice";
 
 const clickOnNext = form => {
   const forwardButton = form.find(".forward");
@@ -18,6 +19,11 @@ const writeInFreeText = (form, text) => {
 
 const clickOnSingleChoice = (form, choice) => {
   const answer = form.find(SingleChoice).find({ title: choice });
+  answer.simulate("click");
+};
+
+const clickOnMultipleChoice = (form, choice) => {
+  const answer = form.find(MultipleChoice).find({ title: choice });
   answer.simulate("click");
 };
 
@@ -93,7 +99,7 @@ describe("Form", () => {
       {
         id: 1,
         questionText: "Ai peste 60 de ani?",
-        answer: "1"
+        answer: 1
       }
     ]);
   });
@@ -147,6 +153,74 @@ describe("Form", () => {
         id: 1,
         questionText: "Care este numele tau?",
         answer: "Jane Doe"
+      }
+    ]);
+  });
+
+  it("Finalised the form with correct output when using a multiple choice", () => {
+    const multiChoiceForm = {
+      title: "Multiple choice form",
+      formId: 1,
+      firstNodeId: 1,
+      form: [
+        {
+          questionId: 1,
+          questionText: "Ce simptome ai?",
+          type: "MULTIPLE_CHOICE",
+          options: [
+            {
+              label: "Tuse",
+              value: 0
+            },
+            {
+              type: "OTHER",
+              label: "Febra",
+              value: 1
+            },
+            {
+              type: "OTHER",
+              label: "Altceva",
+              value: 2
+            }
+          ]
+        },
+        {
+          questionId: 2,
+          questionText: "Done!",
+          type: "FINAL",
+          options: [
+            outcome,
+            {
+              label: "Stay at home",
+              value: 1
+            }
+          ]
+        }
+      ]
+    };
+
+    const mockFinishingForm = jest.fn();
+    const form = mount(
+      <Form
+        data={multiChoiceForm}
+        evaluateForm={() => {
+          return outcome;
+        }}
+        onFinishingForm={mockFinishingForm}
+      />
+    );
+
+    clickOnMultipleChoice(form, "Tuse");
+    clickOnNext(form);
+
+    expectHeaderText(form, "Done!");
+
+    const actualAnswers = mockFinishingForm.mock.calls[0][0].answers;
+    expect(actualAnswers).toEqual([
+      {
+        id: 1,
+        questionText: "Ce simptome ai?",
+        answer: { 0: true }
       }
     ]);
   });

--- a/src/components/form/form.test.js
+++ b/src/components/form/form.test.js
@@ -99,7 +99,7 @@ describe("Form", () => {
       {
         id: 1,
         questionText: "Ai peste 60 de ani?",
-        answer: 1
+        answer: "1"
       }
     ]);
   });
@@ -211,8 +211,11 @@ describe("Form", () => {
     );
 
     clickOnMultipleChoice(form, "Tuse");
-    clickOnNext(form);
 
+    const altcevaInput = form.find({ label: "Altceva" }).find("input");
+    altcevaInput.simulate("change", { target: { value: "tuse" } });
+
+    clickOnNext(form);
     expectHeaderText(form, "Done!");
 
     const actualAnswers = mockFinishingForm.mock.calls[0][0].answers;
@@ -220,7 +223,7 @@ describe("Form", () => {
       {
         id: 1,
         questionText: "Ce simptome ai?",
-        answer: { 0: true }
+        answer: { 0: true, 2: "tuse" }
       }
     ]);
   });

--- a/src/components/form/freeText.js
+++ b/src/components/form/freeText.js
@@ -39,7 +39,7 @@ FreeText.propTypes = {
     )
   }),
   onAnswer: PropTypes.func,
-  currentResponse: PropTypes.number
+  currentResponse: PropTypes.string
 };
 
 export default FreeText;

--- a/src/components/form/multipleChoice.js
+++ b/src/components/form/multipleChoice.js
@@ -7,9 +7,9 @@ import { Input } from "../input/input";
 import "./multipleChoice.scss";
 
 function MultipleChoice({ question, onAnswer, currentResponse = {} }) {
-  const [answers, setAnswers] = useState({});
+  const [answers, setAnswers] = useState(currentResponse);
   const isSelected = option => {
-    return currentResponse[option.value];
+    return answers[option.value];
   };
 
   const handleClick = option => {
@@ -41,7 +41,7 @@ function MultipleChoice({ question, onAnswer, currentResponse = {} }) {
 
   const choiceFor = option => {
     if (option.type === "OTHER") {
-      const value = currentResponse[option.value];
+      const value = answers[option.value];
       return (
         <div
           className={"__list-item other"}

--- a/src/components/form/multipleChoice.js
+++ b/src/components/form/multipleChoice.js
@@ -6,45 +6,42 @@ import { ListItem } from "../list-item/list-item";
 import { Input } from "../input/input";
 import "./multipleChoice.scss";
 
-function MultipleChoice({ question, onAnswer, currentResponse = [] }) {
-  const [answers, setAnswers] = useState([]);
+function MultipleChoice({ question, onAnswer, currentResponse = {} }) {
+  const [answers, setAnswers] = useState({});
   const isSelected = option => {
-    return currentResponse.includes(option.value);
+    return currentResponse[option.value];
   };
 
   const handleClick = option => {
-    let newAnswers;
-    if (answers.includes(option.value)) {
-      newAnswers = answers.filter(item => item !== option.value);
+    if (answers[option.value]) {
+      delete answers[option.value];
     } else {
-      newAnswers = [...answers, option.value];
+      answers[option.value] = true;
     }
-    setAnswers(newAnswers);
+    setAnswers(answers);
     onAnswer({
       questionId: question.questionId,
-      value: newAnswers
+      value: answers
     });
   };
 
-  const onInputForOther = event => {
-    let newValueForAnswers = [...answers];
-    if (event.target.value !== "") {
-      newValueForAnswers = [...answers, event.target.value];
+  const onInputForOther = (optionId, optionValue) => {
+    answers[optionId] = optionValue;
+
+    if (optionValue === "") {
+      delete answers[optionId];
     }
 
+    setAnswers(answers);
     onAnswer({
       questionId: question.questionId,
-      value: newValueForAnswers
+      value: answers
     });
   };
 
   const choiceFor = option => {
     if (option.type === "OTHER") {
-      const size = currentResponse.length;
-      let existingValue = "";
-      if (size > 0 && isNaN(currentResponse[size - 1])) {
-        existingValue = currentResponse[size - 1];
-      }
+      const value = currentResponse[option.value];
       return (
         <div
           className={"__list-item other"}
@@ -52,8 +49,10 @@ function MultipleChoice({ question, onAnswer, currentResponse = [] }) {
         >
           <Input
             usePlaceholder={false}
-            onChange={onInputForOther}
-            defaultValue={existingValue}
+            onChange={event => {
+              onInputForOther(String(option.value), event.target.value);
+            }}
+            defaultValue={value ? value : ""}
             label={option.label}
           />
         </div>
@@ -96,6 +95,6 @@ MultipleChoice.propTypes = {
     )
   }),
   onAnswer: PropTypes.func,
-  currentResponse: PropTypes.arrayOf(PropTypes.number)
+  currentResponse: PropTypes.object
 };
 export default MultipleChoice;

--- a/src/components/form/multipleChoice.test.js
+++ b/src/components/form/multipleChoice.test.js
@@ -183,20 +183,37 @@ describe("Multiple choice", () => {
     });
 
     it("handles setting current response", () => {
+      const onAnswerMock = jest.fn();
       const multipleChoice = mount(
         <MultipleChoice
           question={questionWithMultipleFreeText}
-          onAnswer={() => {}}
-          currentResponse={{ "2": "curge nasul" }}
+          onAnswer={onAnswerMock}
+          currentResponse={{ "1": "38", "2": "curge nasul" }}
         />
       );
 
-      const defaultValue = multipleChoice
+      const firstFreeText = multipleChoice
+        .find({ label: "Febra" })
+        .find("input")
+        .props()["defaultValue"];
+
+      const secondFreeText = multipleChoice
         .find({ label: "Altceva" })
         .find("input")
         .props()["defaultValue"];
 
-      expect(defaultValue).toEqual("curge nasul");
+      multipleChoice
+        .find({ label: "Altceva" })
+        .find("input")
+        .simulate("change", { target: { value: "Stranutat" } });
+
+      expect(firstFreeText).toEqual("38");
+      expect(secondFreeText).toEqual("curge nasul");
+
+      expect(onAnswerMock).toHaveBeenLastCalledWith({
+        questionId: 1,
+        value: { "1": "38", "2": "Stranutat" }
+      });
     });
   });
 });

--- a/src/components/form/multipleChoice.test.js
+++ b/src/components/form/multipleChoice.test.js
@@ -37,7 +37,7 @@ describe("Multiple choice", () => {
 
     expect(onAnswerMock).toHaveBeenCalledWith({
       questionId: 1,
-      value: [0, 2]
+      value: { "0": true, "2": true }
     });
   });
 
@@ -52,6 +52,28 @@ describe("Multiple choice", () => {
           value: 0
         },
         {
+          label: "Febra",
+          value: 1
+        },
+        {
+          type: "OTHER",
+          label: "Altceva",
+          value: 2
+        }
+      ]
+    };
+
+    const questionWithMultipleFreeText = {
+      questionId: 1,
+      questionText: "Ce simptome ai?",
+      type: "MULTIPLE_CHOICE",
+      options: [
+        {
+          label: "Tuse",
+          value: 0
+        },
+        {
+          type: "OTHER",
           label: "Febra",
           value: 1
         },
@@ -80,7 +102,7 @@ describe("Multiple choice", () => {
 
       expect(onAnswerMock).toHaveBeenLastCalledWith({
         questionId: 1,
-        value: [0, "Stranutat"]
+        value: { "0": true, "2": "Stranutat" }
       });
     });
 
@@ -104,7 +126,33 @@ describe("Multiple choice", () => {
 
       expect(onAnswerMock).toHaveBeenLastCalledWith({
         questionId: 1,
-        value: ["Curge nasul"]
+        value: { "2": "Curge nasul" }
+      });
+    });
+
+    it("handles multiple free text entries", () => {
+      const onAnswerMock = jest.fn();
+      const multipleChoice = mount(
+        <MultipleChoice
+          question={questionWithMultipleFreeText}
+          onAnswer={onAnswerMock}
+          currentResponse={undefined}
+        />
+      );
+
+      multipleChoice
+        .find({ label: "Febra" })
+        .find("input")
+        .simulate("change", { target: { value: "Stranutat" } });
+
+      multipleChoice
+        .find({ label: "Altceva" })
+        .find("input")
+        .simulate("change", { target: { value: "Curge nasul" } });
+
+      expect(onAnswerMock).toHaveBeenLastCalledWith({
+        questionId: 1,
+        value: { "1": "Stranutat", "2": "Curge nasul" }
       });
     });
 
@@ -130,20 +178,23 @@ describe("Multiple choice", () => {
 
       expect(onAnswerMock).toHaveBeenLastCalledWith({
         questionId: 1,
-        value: [0]
+        value: { "0": true }
       });
     });
 
     it("handles setting current response", () => {
       const multipleChoice = mount(
         <MultipleChoice
-          question={question}
+          question={questionWithMultipleFreeText}
           onAnswer={() => {}}
-          currentResponse={["curge nasul"]}
+          currentResponse={{ "2": "curge nasul" }}
         />
       );
 
-      const defaultValue = multipleChoice.find("input").props()["defaultValue"];
+      const defaultValue = multipleChoice
+        .find({ label: "Altceva" })
+        .find("input")
+        .props()["defaultValue"];
 
       expect(defaultValue).toEqual("curge nasul");
     });


### PR DESCRIPTION
### What changed?
- Added ability to have multiple free text choices in a form

Previously having more than one free text choice on a multiple choice question was buggy as the data model assumed only one free text. Now that changed to cater for multiple values. This meant that the type of the value sent to server for a multiple choice server is an object not a string.

