### PR TITLE
Fixing issue when a date picker question is skipped

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code4ro/taskforce-fe-components",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "private": false,
   "dependencies": {
     "bulma": "^0.8.0",

--- a/src/components/form/form.js
+++ b/src/components/form/form.js
@@ -8,6 +8,7 @@ import StaticText from "./staticText";
 import InputQuestion from "./inputQuestion";
 import MultipleChoice from "./multipleChoice";
 import { DatePicker } from "./datePicker";
+import format from "date-fns/format";
 
 const FIRST_NODE = 1;
 
@@ -44,21 +45,20 @@ export const Form = ({ data, evaluateForm, onFinishingForm }) => {
         return {};
       }
 
-      let answer = formState[id];
+      const rawAnswer = formState[id];
 
+      let answer = rawAnswer;
       if (question.type === "SINGLE_CHOICE") {
-        answer = String(answer);
+        answer = String(rawAnswer);
       }
 
       if (
         question.type === "DATE_PICKER" ||
         question.type === "DATE_TIME_PICKER"
       ) {
-        //little hack as seen here
-        // https://stackoverflow.com/questions/10830357/javascript-toisostring-ignores-timezone-offset
-        // to get around the fact that toISOString always returns on UTC
-        const tzoffset = answer.getTimezoneOffset() * 60000; //offset in milliseconds
-        answer = new Date(answer - tzoffset).toISOString().slice(0, -1);
+        answer = rawAnswer
+          ? format(rawAnswer, "yyyy-MM-dd'T'HH:mm")
+          : rawAnswer;
       }
 
       return {

--- a/src/components/form/form.test.js
+++ b/src/components/form/form.test.js
@@ -287,12 +287,12 @@ describe("Form", () => {
       {
         id: 1,
         questionText: "De la ce data ai inceput sa ai simptome?",
-        answer: "2020-05-20T00:00:00.000"
+        answer: "2020-05-20T00:00"
       },
       {
         id: 2,
         questionText: "La ce data si ora ai iesit afara?",
-        answer: "2020-05-20T11:10:00.000"
+        answer: "2020-05-20T11:10"
       }
     ]);
   });


### PR DESCRIPTION
The issue was due to the lack of a null/undefined check - which now has been added

Also removed the hack used to format the date and used the date-fns library to do the formatting of datetime.

