### PR TITLE
Adding the ability to use the default next question on the question

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code4ro/taskforce-fe-components",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "private": false,
   "dependencies": {
     "bulma": "^0.8.0",

--- a/src/components/form/data/decisionTree.js
+++ b/src/components/form/data/decisionTree.js
@@ -80,6 +80,7 @@ export default {
     },
     {
       questionId: 7,
+      nextQuestionId: 100,
       questionText: "Ce simptome ai?",
       type: "MULTIPLE_CHOICE",
       options: [
@@ -100,7 +101,7 @@ export default {
       ]
     },
     {
-      questionId: 8,
+      questionId: 100,
       type: "FINAL",
       questionText: "Ce trebuie sa faci?",
       options: [

--- a/src/components/form/form.js
+++ b/src/components/form/form.js
@@ -168,8 +168,7 @@ export const Form = ({ data, evaluateForm, onFinishingForm }) => {
     if (formState[currentElement.questionId] !== undefined) {
       const optionValue = formState[currentElement.questionId];
       const defaultNext = currentElement.nextQuestionId
-        ? currentElement.nextQuestionId
-        : currentNode + 1;
+        || currentNode + 1;
 
       const nextNode =
         getNextQuestionForOptionValue(currentElement, optionValue) ||

--- a/src/components/form/form.js
+++ b/src/components/form/form.js
@@ -167,8 +167,7 @@ export const Form = ({ data, evaluateForm, onFinishingForm }) => {
     const currentElement = formAsMap[currentNode];
     if (formState[currentElement.questionId] !== undefined) {
       const optionValue = formState[currentElement.questionId];
-      const defaultNext = currentElement.nextQuestionId
-        || currentNode + 1;
+      const defaultNext = currentElement.nextQuestionId || currentNode + 1;
 
       const nextNode =
         getNextQuestionForOptionValue(currentElement, optionValue) ||

--- a/src/components/form/form.js
+++ b/src/components/form/form.js
@@ -167,7 +167,9 @@ export const Form = ({ data, evaluateForm, onFinishingForm }) => {
     const currentElement = formAsMap[currentNode];
     if (formState[currentElement.questionId] !== undefined) {
       const optionValue = formState[currentElement.questionId];
-      const defaultNext = currentNode + 1;
+      const defaultNext = currentElement.nextQuestionId
+        ? currentElement.nextQuestionId
+        : currentNode + 1;
 
       const nextNode =
         getNextQuestionForOptionValue(currentElement, optionValue) ||

--- a/src/components/form/form.stories.js
+++ b/src/components/form/form.stories.js
@@ -8,11 +8,7 @@ import { Form } from "./form";
 export default { title: "Form" };
 
 let evaluate = function(formData, options) {
-  if (formData[1]) {
-    return options[1];
-  } else {
-    return options[0];
-  }
+  return options[0];
 };
 export const withCeMaFacData = () => (
   <Form

--- a/src/components/form/form.test.js
+++ b/src/components/form/form.test.js
@@ -46,6 +46,13 @@ const expectHeaderText = (form, expected) => {
   expect(form.find(ListHeader).text()).toEqual(expected);
 };
 
+const finalEntryWithId = id => ({
+  questionId: id,
+  questionText: "Done!",
+  type: "FINAL",
+  options: [outcome]
+});
+
 const oneQuestionForm = {
   title: "One question form",
   formId: 1,
@@ -66,18 +73,7 @@ const oneQuestionForm = {
         }
       ]
     },
-    {
-      questionId: 2,
-      questionText: "Done!",
-      type: "FINAL",
-      options: [
-        outcome,
-        {
-          label: "Stay at home",
-          value: 1
-        }
-      ]
-    }
+    finalEntryWithId(2)
   ]
 };
 
@@ -122,18 +118,7 @@ describe("Form", () => {
           type: "INPUT",
           options: []
         },
-        {
-          questionId: 2,
-          questionText: "Done!",
-          type: "FINAL",
-          options: [
-            outcome,
-            {
-              label: "Stay at home",
-              value: 1
-            }
-          ]
-        }
+        finalEntryWithId(2)
       ]
     };
 
@@ -190,18 +175,7 @@ describe("Form", () => {
             }
           ]
         },
-        {
-          questionId: 2,
-          questionText: "Done!",
-          type: "FINAL",
-          options: [
-            outcome,
-            {
-              label: "Stay at home",
-              value: 1
-            }
-          ]
-        }
+        finalEntryWithId(2)
       ]
     };
 
@@ -250,12 +224,7 @@ describe("Form", () => {
           questionText: "La ce data si ora ai iesit afara?",
           type: "DATE_TIME_PICKER"
         },
-        {
-          questionId: 3,
-          type: "FINAL",
-          questionText: "Done!",
-          options: [outcome]
-        }
+        finalEntryWithId(3)
       ]
     };
 
@@ -297,6 +266,49 @@ describe("Form", () => {
     ]);
   });
 
+  it("Uses the default next question on the question itself", () => {
+    const formWithDefaultNextQuestion = {
+      title: "Form with default next question",
+      formId: 1,
+      firstNodeId: 1,
+      form: [
+        {
+          questionId: 1,
+          nextQuestionId: 10,
+          questionText: "Ai peste 60 de ani?",
+          type: "SINGLE_CHOICE",
+          options: [
+            {
+              label: "Da",
+              value: 1
+            },
+            {
+              label: "Nu",
+              value: 0
+            }
+          ]
+        },
+        finalEntryWithId(10)
+      ]
+    };
+    const mockFinishingForm = jest.fn();
+
+    const form = mount(
+      <Form
+        data={formWithDefaultNextQuestion}
+        evaluateForm={() => {
+          return outcome;
+        }}
+        onFinishingForm={mockFinishingForm}
+      />
+    );
+
+    clickOnSingleChoice(form, "Da");
+    clickOnNext(form);
+
+    expectHeaderText(form, "Done!");
+  });
+
   it("Shows blurb at the beginning if it exists", () => {
     const formWithStartingBlurb = {
       title: "Form with starting blurb",
@@ -313,18 +325,7 @@ describe("Form", () => {
           type: "INPUT",
           options: []
         },
-        {
-          questionId: 2,
-          questionText: "Done!",
-          type: "FINAL",
-          options: [
-            outcome,
-            {
-              label: "Stay at home",
-              value: 1
-            }
-          ]
-        }
+        finalEntryWithId(2)
       ]
     };
     const form = mount(


### PR DESCRIPTION
Update the form navigation to be able to use the `nextQuestionId` on the question as a default to figure what's the next question to display
