### PR TITLE
[Refactor]: Bug smash session 1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7828,6 +7828,24 @@
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
       "dev": true
     },
+    "deprecated-prop-type": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/deprecated-prop-type/-/deprecated-prop-type-1.0.0.tgz",
+      "integrity": "sha512-Hp4VxvZN6IlbKvleZfbdrojOmnPXuRPjC9cQ82j6bdI3DRCwGR+7CEf367X59MHz/y8Ao/mxdP7YyR3KTb+EhQ==",
+      "requires": {
+        "warning": "4.0.1"
+      },
+      "dependencies": {
+        "warning": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.1.tgz",
+          "integrity": "sha512-rAVtTNZw+cQPjvGp1ox0XC5Q2IBFyqoqh+QII4J/oguyu83Bax1apbo2eqB8bHRS+fqYUBagys6lqUoVwKSmXQ==",
+          "requires": {
+            "loose-envify": "^1.0.0"
+          }
+        }
+      }
+    },
     "des.js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@code4ro/taskforce-fe-components",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code4ro/taskforce-fe-components",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "private": false,
   "dependencies": {
     "bulma": "^0.8.0",

--- a/package.json
+++ b/package.json
@@ -5,11 +5,13 @@
   "dependencies": {
     "bulma": "^0.8.0",
     "date-fns": "^2.11.1",
+    "deprecated-prop-type": "^1.0.0",
     "echarts": "^4.7.0",
     "echarts-for-react": "^2.0.15-beta.1",
     "react-datepicker": "^2.14.1",
     "react-share": "^4.1.0",
-    "underscore": "^1.9.2"
+    "underscore": "^1.9.2",
+    "warning": "^4.0.3"
   },
   "peerDependencies": {
     "prop-types": ">= 15.7.2 < 2",

--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -39,7 +39,7 @@ export const Button = ({
 
 Button.propTypes = {
   children: PropTypes.node.isRequired,
-  onClick: PropTypes.func.isRequired,
+  onClick: PropTypes.func,
   type: PropTypes.oneOf(["primary", "danger"]),
   size: PropTypes.oneOf(["small", "medium", "large"]),
   disabled: PropTypes.bool,

--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -40,7 +40,7 @@ export const Button = ({
 Button.propTypes = {
   children: PropTypes.node.isRequired,
   onClick: PropTypes.func,
-  type: PropTypes.oneOf(["primary", "danger"]),
+  type: PropTypes.oneOf(["primary", "danger", "warning"]),
   size: PropTypes.oneOf(["small", "medium", "large"]),
   disabled: PropTypes.bool,
   inverted: PropTypes.bool,

--- a/src/components/button/button.stories.js
+++ b/src/components/button/button.stories.js
@@ -47,3 +47,11 @@ export const danger = () => {
     </Button>
   );
 };
+
+export const warning = () => {
+  return (
+    <Button type="warning" onClick={sayMyName}>
+      Hello Friend
+    </Button>
+  );
+};

--- a/src/components/dropdown-search/dropdown-search.js
+++ b/src/components/dropdown-search/dropdown-search.js
@@ -29,6 +29,18 @@ export const DropdownSearch = ({
     onSelect(option);
   };
 
+  const onDropdownKeyPress = event => {
+    if (event.key === "Enter") {
+      toggleDropdownOptions();
+    }
+  };
+
+  const onItemKeyPress = (event, option) => {
+    if (event.key === "Enter") {
+      selectDropdownOption(option);
+    }
+  };
+
   const toggleDropdownOptions = () => {
     setShowDropdownOptions(!showDropdownOptions);
   };
@@ -49,7 +61,12 @@ export const DropdownSearch = ({
 
   return (
     <div>
-      <div className="dropdown-search-filter" onClick={toggleDropdownOptions}>
+      <div
+        tabIndex={0}
+        className="dropdown-search-filter"
+        onKeyPress={onDropdownKeyPress}
+        onClick={toggleDropdownOptions}
+      >
         <div className="dropdown-search-filter__name">{dropdownTitle}</div>
         <span className="icon is-small is-right dropdown-search-filter__icon">
           <ArrowDown />
@@ -72,9 +89,11 @@ export const DropdownSearch = ({
               {dropdownOptions.map(option => {
                 return (
                   <div
+                    tabIndex={0}
                     className="dropdown-search-options__value"
                     key={option.value}
                     id={option.value}
+                    onKeyPress={e => onItemKeyPress(e, option)}
                     onClick={() => {
                       selectDropdownOption(option);
                     }}

--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -75,12 +75,12 @@ export const Input = ({
           name={name}
           disabled={disabled}
           defaultValue={defaultValue}
-          placeholder={usePlaceholder && label}
+          placeholder={usePlaceholder ? label : ""}
           onChange={onChange}
           required={required}
-          min={type === "number" && min}
-          max={type === "number" && max}
-          step={type === "number" && step}
+          min={type === "number" && min ? min : void 0}
+          max={type === "number" && max ? max : void 0}
+          step={type === "number" && step ? step : void 0}
           minLength={minLength}
           maxLength={maxLength}
           ref={inputRef}
@@ -105,7 +105,7 @@ Input.propTypes = {
   loading: PropTypes.bool,
   rounded: PropTypes.bool,
   required: PropTypes.bool,
-  defaultValue: PropTypes.string,
+  defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   usePlaceholder: PropTypes.bool,
   children: PropTypes.node,
   color: PropTypes.oneOf(["primary", "info", "success", "warning", "danger"]),

--- a/src/components/input/input.stories.js
+++ b/src/components/input/input.stories.js
@@ -24,8 +24,8 @@ export const types = () => (
     />
     <Input type="password" label="Password" />
     <Input type="number" label="Free-range number" />
-    <Input type="number" min="1" max="3" label="Restricted number" />
-    <Input type="number" min="0" max="10" step="2" label="Number with step" />
+    <Input type="number" min={1} max={3} label="Restricted number" />
+    <Input type="number" min={0} max={10} step={2} label="Number with step" />
 
     <input type="submit" value="Validate inputs" />
     {/* Please see
@@ -126,7 +126,7 @@ export const events = () => {
     <div style={style}>
       <Input
         label="Type something..."
-        usePlaceholder="true"
+        usePlaceholder={true}
         onChange={e => setInputValue(e.target.value)}
       />
       <label>{inputValue}</label>

--- a/src/components/input/input.stories.js
+++ b/src/components/input/input.stories.js
@@ -105,9 +105,9 @@ export const validation = () => (
       <Input
         type="number"
         validationMessages={numberMessages}
-        min="1"
-        max="7"
-        step="2"
+        min={1}
+        max={7}
+        step={2}
         required
         label="Restircted number validation (required, min(3), max(7), step(2))"
       />

--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -20,7 +20,7 @@ export const Select = ({
   selectProps,
   defaultValue
 }) => {
-  const [currentValue, setCurrentValue] = useState("");
+  const [currentValue, setCurrentValue] = useState();
 
   useEffect(() => {
     const selectedOptions = options.filter(opt => opt.selected);
@@ -92,6 +92,5 @@ Select.defaultProps = {
   label: "",
   description: "",
   selectProps: {},
-  defaultValue: "",
   options: []
 };

--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -5,26 +5,32 @@ import PropTypes from "prop-types";
  *
  * @param {string} label
  * @param {string} description
- * @param {[{ text: string, value: string, selected?:boolean }]}
- * options List of select options with key, value and selected properties
+ * @param {[{ text: string, value: string | number, disabled?: boolean }]} options
+ * List of select options with key, value and disabled properties
  * @param {object} selectProps Contains HTML input attributes:
  * type, value, name, id, etc. https://www.w3schools.com/tags/tag_select.asp
+ * @param {string | number} defaultValue
  */
-export const Select = ({ label, description, options, selectProps }) => {
+export const Select = ({
+  label,
+  description,
+  options,
+  selectProps,
+  defaultValue
+}) => {
   return (
     <div className="field">
       <label className="label">{label}</label>
       <p className="subtitle is-2">{description}</p>
       <div className="control">
         <div className="select">
-          <select {...selectProps}>
+          <select ref={selectEl} {...selectProps} defaultValue={defaultValue}>
             {options &&
               options.map((option, index) => {
                 return (
                   <option
                     key={`key_${option.value}_${index}`}
                     value={option.value}
-                    selected={option.selected === true}
                     disabled={option.disabled === true}
                   >
                     {option.text}
@@ -41,12 +47,13 @@ export const Select = ({ label, description, options, selectProps }) => {
 Select.propTypes = {
   label: PropTypes.node.isRequired,
   description: PropTypes.node.isRequired,
-  selectProps: PropTypes.node.IsOptional,
+  selectProps: PropTypes.object,
+  defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   options: PropTypes.arrayOf(
     PropTypes.shape({
       text: PropTypes.string,
       value: PropTypes.string,
-      selected: PropTypes.bool
+      disabled: PropTypes.bool
     })
   )
 };
@@ -55,5 +62,6 @@ Select.defaultProps = {
   label: "",
   description: "",
   selectProps: {},
+  defaultValue: null,
   options: []
 };

--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -1,5 +1,7 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import PropTypes from "prop-types";
+import deprecated from "deprecated-prop-type";
+import warning from "warning";
 
 /**
  *
@@ -18,6 +20,21 @@ export const Select = ({
   selectProps,
   defaultValue
 }) => {
+  const selectEl = useRef(null);
+
+  useEffect(() => {
+    const selectedOptions = options.filter(opt => opt.selected);
+
+    if (selectedOptions.length) {
+      const [option] = selectedOptions;
+      selectEl.current.value = option.value;
+
+      if (selectedOptions.length > 1) {
+        warning(false, "Only one 'selected' property of 'Select' can be true");
+      }
+    }
+  }, []);
+
   return (
     <div className="field">
       <label className="label">{label}</label>
@@ -53,7 +70,8 @@ Select.propTypes = {
     PropTypes.shape({
       text: PropTypes.string,
       value: PropTypes.string,
-      disabled: PropTypes.bool
+      disabled: PropTypes.bool,
+      selected: deprecated(PropTypes.bool, "Use `defaultValue` prop instead.")
     })
   )
 };

--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import deprecated from "deprecated-prop-type";
 import warning from "warning";
@@ -11,7 +11,7 @@ import warning from "warning";
  * List of select options with key, value and disabled properties
  * @param {object} selectProps Contains HTML input attributes:
  * type, value, name, id, etc. https://www.w3schools.com/tags/tag_select.asp
- * @param {string | number} defaultValue
+ * @param { string | number } defaultValue
  */
 export const Select = ({
   label,
@@ -20,20 +20,32 @@ export const Select = ({
   selectProps,
   defaultValue
 }) => {
-  const selectEl = useRef(null);
+  const [currentValue, setCurrentValue] = useState("");
 
   useEffect(() => {
     const selectedOptions = options.filter(opt => opt.selected);
 
     if (selectedOptions.length) {
       const [option] = selectedOptions;
-      selectEl.current.value = option.value;
+      setCurrentValue(option.value);
 
       if (selectedOptions.length > 1) {
         warning(false, "Only one 'selected' property of 'Select' can be true");
       }
     }
-  }, []);
+
+    if (defaultValue) {
+      setCurrentValue(defaultValue);
+    }
+  }, [defaultValue]);
+
+  const onChange = e => {
+    if (selectProps.onChange && typeof selectProps.onChange === "function") {
+      selectProps.onChange(e);
+    }
+
+    setCurrentValue(e.target.value);
+  };
 
   return (
     <div className="field">
@@ -41,7 +53,7 @@ export const Select = ({
       <p className="subtitle is-2">{description}</p>
       <div className="control">
         <div className="select">
-          <select ref={selectEl} {...selectProps} defaultValue={defaultValue}>
+          <select {...selectProps} onChange={onChange} value={currentValue}>
             {options &&
               options.map((option, index) => {
                 return (
@@ -80,6 +92,6 @@ Select.defaultProps = {
   label: "",
   description: "",
   selectProps: {},
-  defaultValue: null,
+  defaultValue: "",
   options: []
 };

--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -69,7 +69,7 @@ Select.propTypes = {
   options: PropTypes.arrayOf(
     PropTypes.shape({
       text: PropTypes.string,
-      value: PropTypes.string,
+      value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
       disabled: PropTypes.bool,
       selected: deprecated(PropTypes.bool, "Use `defaultValue` prop instead.")
     })

--- a/src/components/select/select.stories.js
+++ b/src/components/select/select.stories.js
@@ -10,7 +10,7 @@ export const SelectWithChangeEvent = () => {
     { text: "Option 2", value: "value2" },
     { text: "Option 3", value: "value3" }
   ];
-  const [textValue, setTextValue] = useState("Option 3");
+  const [textValue, setTextValue] = useState("value3");
   const props = {
     onChange: function(el) {
       setTextValue(el.target.value);
@@ -46,7 +46,7 @@ export const DependentSelects = () => {
     }
     return generatedOptions;
   };
-  const [childOptions, setChildOptions] = useState(generateOptions("Value 1"));
+  const [childOptions, setChildOptions] = useState(generateOptions("value1"));
 
   const props = {
     onChange: function(el) {

--- a/src/components/select/select.stories.js
+++ b/src/components/select/select.stories.js
@@ -7,10 +7,10 @@ export default { title: "Select" };
 export const SelectWithChangeEvent = () => {
   let options = [
     { text: "Option 1", value: "value1", disabled: true },
-    { text: "Option 2", value: "value2", selected: true },
+    { text: "Option 2", value: "value2" },
     { text: "Option 3", value: "value3" }
   ];
-  const [textValue, setTextValue] = useState("Option 1");
+  const [textValue, setTextValue] = useState("Option 3");
   const props = {
     onChange: function(el) {
       setTextValue(el.target.value);
@@ -22,6 +22,7 @@ export const SelectWithChangeEvent = () => {
       <Select
         label={"Select with onChange event"}
         selectProps={props}
+        defaultValue={options[2].value}
         options={options}
       />
       {textValue && `Selected: ${textValue}`}


### PR DESCRIPTION
### What changed?
 - Makes `onClick` callback optional for the `button`
 - Adds `warning` type for the `button`
 - Adds initial tab navigation for `searchDropdown` (We can navigate with tab, open the dropdown and select an item by pressing Enter)
 -  Changes `defaultValue` selection and fixes some type errors for the `Select` component and adds deprecation message for the usage of `options.selected` field.
 - Change the `Select` input from uncontrolled to controlled.
 - Fixes some type errors for the `input`

ℹ️ Please note that there is a glitch for the deprecated `option.selected` version where the default value will be the first element in the options, and at the next render the default value is updated manually with the first `option.selected = true`.

### TODO:
- [x] Make the select component a controlled input instead of uncontrolled one

### Actions (optional)
 - [x] Increase the version of the package if you need to release it after the merge
 - [x] ~If you added a new component, please make sure to export it in `../src/index.js`~