### PR TITLE
fix: style for days outside month

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code4ro/taskforce-fe-components",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "private": false,
   "dependencies": {
     "bulma": "^0.8.0",

--- a/src/components/form/datePicker.css
+++ b/src/components/form/datePicker.css
@@ -1,3 +1,7 @@
-.date-picker > div:nth-child(2) {
-    width: 100%;
+.date-picker>div:nth-child(2) {
+  width: 100%;
+}
+
+.react-datepicker__day--outside-month {
+  color: #bbbbbb;
 }


### PR DESCRIPTION
### What changed?
 - Now the user is able to distinguish between days in the current month and other days
 - Requested in [stam-acasa](https://github.com/code4romania/stam-acasa/issues/349)

### Actions (optional)
 - [x] Increase the version of the package if you need to release it after the merge

