### PR TITLE
feat(date-picker-form): Implemented not allowing future dates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@code4ro/taskforce-fe-components",
-  "version": "1.0.13",
+  "version": "1.0.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code4ro/taskforce-fe-components",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "private": false,
   "dependencies": {
     "bulma": "^0.8.0",

--- a/src/components/form/data/datePickers.js
+++ b/src/components/form/data/datePickers.js
@@ -10,11 +10,23 @@ export default {
     },
     {
       questionId: 2,
+      questionText: "De la ce data re-incepi lucrul?",
+      type: "DATE_PICKER",
+      allowFuture: true
+    },
+    {
+      questionId: 3,
       questionText: "La ce data si ora ai iesit afara?",
       type: "DATE_TIME_PICKER"
     },
     {
-      questionId: 3,
+      questionId: 4,
+      questionText: "La ce data si ora esti programat la medic?",
+      type: "DATE_TIME_PICKER",
+      allowFuture: true
+    },
+    {
+      questionId: 5,
       type: "FINAL",
       questionText: "Ce trebuie sa faci?",
       options: [


### PR DESCRIPTION
### What changed?
Implemented not allowing future dates by default for date and datetime inputs in forms.
The default [was decided](https://github.com/code4romania/stam-acasa/issues/348#issuecomment-619366353) to be not to allow future dates. 
 
 Closes https://github.com/code4romania/stam-acasa/issues/365 
 Closes https://github.com/code4romania/stam-acasa/issues/348

### Actions (optional)
 - [X] Increase the version of the package if you need to release it after the merge
 - [ ] If you added a new component, please make sure to export it in `../src/index.js`

