### PR TITLE
Adding the css of the date picker back

### DIFF
--- a/src/components/form/datePicker.scss
+++ b/src/components/form/datePicker.scss
@@ -1,4 +1,4 @@
-// @import "react-datepicker/dist/react-datepicker.css";
+@import "~react-datepicker/dist/react-datepicker.css";
 
 .date-picker > div:nth-child(2) {
   width: 100%;


### PR DESCRIPTION
Fixes issue with styling not loading for the datepicker

This doesnt fix the issue of bulma not being loaded, it fixes the styling for the date picker. Hence that can be checked on vercel

