### PR TITLE
Add banner image

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@code4ro/taskforce-fe-components",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code4ro/taskforce-fe-components",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": false,
   "sideEffects": false,
   "dependencies": {

--- a/src/components/banner-image/baner-image.stories.js
+++ b/src/components/banner-image/baner-image.stories.js
@@ -1,0 +1,13 @@
+import React from "react";
+import { BannerImage } from "./banner-image";
+
+export default { title: "Banner Image" };
+
+export const Default = () => (
+  <BannerImage
+    link="https://code4.ro"
+    image={
+      {src: "https://stirioficiale.ro/storage/imagine principala_ROVACCINARE.png"}
+    }
+  />
+);

--- a/src/components/banner-image/banner-image.js
+++ b/src/components/banner-image/banner-image.js
@@ -1,0 +1,31 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+export const BannerImage = ({ image: {src, alt, title}, link }) => {
+  return (
+    <div>
+      {link ?
+        <a href={link} target="_blank" rel="noopener noreferrer">
+          <img src={src} alt={alt} title={title}/>
+        </a>
+        :
+        <img src={src} alt={alt} title={title}/>
+      }
+    </div>
+  );
+};
+
+BannerImage.propTypes = {
+  image: PropTypes.shape({
+    src: PropTypes.string.isRequired,
+    alt: PropTypes.string,
+    title: PropTypes.string
+  }).isRequired,
+  link: PropTypes.string
+};
+
+BannerImage.defaultProps = {
+  link: null
+}
+
+

--- a/src/components/instruments/instruments.stories.js
+++ b/src/components/instruments/instruments.stories.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { Instruments } from "./instruments";
 import { InstrumentsItem } from "../instruments-item/instruments-item";
+import { BannerImage } from "../banner-image/banner-image";
 
 export default { title: "Instruments" };
 
@@ -9,6 +10,15 @@ const showMessage = () => alert("Hello, friend.");
 export const grid = () => (
   <Instruments layout="grid">
     <section>
+      <BannerImage
+        link="https://vaccinare-covid.gov.ro/"
+        image={{
+          src:
+            "https://stirioficiale.ro/storage/imagine principala_ROVACCINARE.png",
+          alt: "#ROVACCINARE",
+          title: "#ROVACCINARE"
+        }}
+      />
       <InstrumentsItem
         color="yellow"
         title="Instalează-ți add-on-ul de depistat știrile false"
@@ -17,6 +27,8 @@ export const grid = () => (
         color="blue"
         title="Instalează-ți add-on-ul de depistat știrile false"
       />
+    </section>
+    <section>
       <InstrumentsItem
         color="green"
         title="Stiri oficiale si informații la zi"
@@ -24,8 +36,6 @@ export const grid = () => (
         ctaText="Cele mai noi informații oficiale"
         onClick={showMessage}
       />
-    </section>
-    <section>
       <InstrumentsItem
         color="red"
         title="Vrei să ajuți. Intră aici"
@@ -55,6 +65,15 @@ export const grid = () => (
 
 export const oneColumn = () => (
   <Instruments layout="column">
+    <BannerImage
+      link="https://vaccinare-covid.gov.ro/"
+      image={{
+        src:
+            "https://stirioficiale.ro/storage/imagine principala_ROVACCINARE.png",
+        alt: "#ROVACCINARE",
+        title: "#ROVACCINARE"
+      }}
+    />
     <InstrumentsItem
       color="green"
       title="Instalează-ți add-on-ul de depistat știrile false"

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ export { Hero } from "./components/hero/hero";
 export { IncubatedBy } from "./components/incubated-by/incubated-by";
 
 export { Banner } from "./components/banner/banner";
+export { BannerImage } from "./components/banner-image/banner-image";
 
 export { Instruments } from "./components/instruments/instruments";
 export { InstrumentsItem } from "./components/instruments-item/instruments-item";


### PR DESCRIPTION
### What changed?
 - Add new Banner image to be used in `Intruments` component
<img width="407" alt="Screenshot 2020-12-11 at 17 16 08" src="https://user-images.githubusercontent.com/6429818/101920548-9db62e80-3bd4-11eb-9435-7bc3f5dac419.png">
- Closes <!-- If it is related to an open issue, please link the issue here. -->

### Actions (optional)
 - [x] Increase the version of the package if you need to release it after the merge
 - [x] If you added a new component, please make sure to export it in `../src/index.js`

